### PR TITLE
Fix for https://github.com/eduardoRoth/media-player/issues/72: Fix lo…

### DIFF
--- a/ios/Sources/MediaPlayerPlugin/MediaPlayerController.swift
+++ b/ios/Sources/MediaPlayerPlugin/MediaPlayerController.swift
@@ -132,6 +132,11 @@ public class MediaPlayerController: UIViewController {
         setLayoutConstraints()
     }
 
+    public func isAudioOnly() -> Bool {
+        let tracks = videoAsset.tracks(withMediaType: .video)
+        return tracks.isEmpty
+    }
+
     public func setLoading(isLoading: Bool) {
         if isLoading {
             self.loadingView.startAnimating()


### PR DESCRIPTION
Fixes #72 "Loading animation covers play button with mp3's on iOS"

+ Adds `isAudioOnly` method in MediaPlayerController.swift
+ Adds buffer checks for audio only playback scenarios and toggles loading in MediaPlayerControllerObservers.swift